### PR TITLE
Fix missing toolbar on SwiftUI keyboard on iOS 18

### DIFF
--- a/IQKeyboardToolbarManager/Classes/Toolbar/IQKeyboardToolbarManager+Toolbar.swift
+++ b/IQKeyboardToolbarManager/Classes/Toolbar/IQKeyboardToolbarManager+Toolbar.swift
@@ -171,12 +171,16 @@ private extension IQKeyboardToolbarManager {
         guard let inputAccessoryView: UIView = textInputView.inputAccessoryView,
               inputAccessoryView.tag != IQKeyboardToolbarManager.toolbarTag else { return false }
 
-        let swiftUIAccessoryName: String = "InputAccessoryHost<InputAccessoryBar>"
+        let swiftUIAccessoryNamePrefixes: [String] = [
+            "RootUIView",   // iOS 18
+            "InputAccessoryHost<InputAccessoryBar>" // iOS 17 and below
+        ]
         let classNameString: String = "\(type(of: inputAccessoryView.classForCoder))"
 
         // If it's SwiftUI accessory view but doesn't have a height (fake accessory view), then we should
         // add our own accessoryView otherwise, keep the SwiftUI accessoryView since user has added it from code
-        guard classNameString.hasPrefix(swiftUIAccessoryName), inputAccessoryView.subviews.isEmpty else {
+        guard swiftUIAccessoryNamePrefixes.contains(where: { classNameString.hasPrefix($0)}),
+              inputAccessoryView.subviews.isEmpty else {
             return true
         }
         return false


### PR DESCRIPTION
# Description

Changed swiftUIAccessoryNames to include the one introduced in iOS 18

Fixes # (issue)
https://github.com/hackiftekhar/IQKeyboardManager/issues/2093
https://github.com/hackiftekhar/IQKeyboardManager/issues/2092

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
