### PR TITLE
Update IQKeyboardToolbar dependency version to 1.1.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/hackiftekhar/IQKeyboardToolbar.git", from: "1.1.1"),
+        .package(url: "https://github.com/hackiftekhar/IQKeyboardToolbar.git", from: "1.1.2"),
         .package(url: "https://github.com/hackiftekhar/IQTextInputViewNotification", from: "1.0.8"),
     ],
     targets: [


### PR DESCRIPTION
# Description

Updates `IQKeyboardToolbar ` dependency to `[1.1.2](https://github.com/hackiftekhar/IQKeyboardToolbar/releases/tag/1.1.2)` so that the [iOS 26 fixes](https://github.com/hackiftekhar/IQKeyboardToolbar/commit/c857e87548ec6b52ba371535b04f1df28d5a3cdc) can be fetched by users who use Swift Package Manager. 

Fixes https://github.com/hackiftekhar/IQKeyboardToolbarManager/issues/7 and https://github.com/hackiftekhar/IQKeyboardManager/issues/2120 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
